### PR TITLE
Disable display refresh rate override

### DIFF
--- a/vendor.prop
+++ b/vendor.prop
@@ -195,6 +195,7 @@ vendor.display.enable_force_split=0
 vendor.display.enable_null_display=0
 vendor.display.enable_optimize_refresh=1
 vendor.gralloc.disable_ubwc=0
+ro.surface_flinger.enable_frame_rate_override=false
 
 # IMS
 persist.dbg.volte_avail_ovr=1


### PR DESCRIPTION
This got enabled by default on U, and it causes apps like Chrome and Youtube to set the refresh rate to 30FPS when playing some videos.